### PR TITLE
Speed up testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
               source virtenv/bin/activate
               pip install --upgrade ansible molecule docker jmespath
 
-              molecule -e molecule/debian9_env.yml test
+              molecule -e ./molecule/debian9_env.yml test
             '''
           }          
         }
@@ -36,7 +36,7 @@ pipeline {
               source virtenv/bin/activate
               pip install --upgrade ansible molecule docker jmespath
           
-              molecule -e molecule/raspbian_stretch_env.yml test
+              molecule -e ./molecule/raspbian_stretch_env.yml test
             '''
           }
         }

--- a/molecule/debian9_env.yml
+++ b/molecule/debian9_env.yml
@@ -1,3 +1,3 @@
 ---
 MOLECULE_DISTRO: debian9
-MOLECULE_IMAGE: dankempster/jenkins-ansible
+MOLECULE_IMAGE: "dankempster/jenkins-ansible:latest"

--- a/molecule/debian9_env.yml
+++ b/molecule/debian9_env.yml
@@ -1,3 +1,3 @@
 ---
 MOLECULE_DISTRO: debian9
-MOLECULE_IMAGE: geerlingguy/docker-debian9-ansible
+MOLECULE_IMAGE: dankempster/jenkins-ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,7 +9,7 @@ lint:
     config-file: yaml-lint.yml
 platforms:
   - name: "${MOLECULE_DISTRO:-debian9}"
-    image: "${MOLECULE_IMAGE:-dankempster/jenkins-ansible}:latest"
+    image: "${MOLECULE_IMAGE:-dankempster/jenkins-ansible:latest}"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,7 +9,7 @@ lint:
     config-file: yaml-lint.yml
 platforms:
   - name: "${MOLECULE_DISTRO:-debian9}"
-    image: "${MOLECULE_IMAGE:-geerlingguy/docker-debian9-ansible}:latest"
+    image: "${MOLECULE_IMAGE:-dankempster/jenkins-ansible}:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -13,10 +13,4 @@
     - role: geerlingguy.git
       become: true
 
-    - role: geerlingguy.java
-      become: true
-
-    - role: geerlingguy.jenkins
-      become: true
-
     - role: ../../../

--- a/molecule/raspbian_jessie_env.yml
+++ b/molecule/raspbian_jessie_env.yml
@@ -1,3 +1,3 @@
 ---
 MOLECULE_DISTRO: rasp_jessie
-MOLECULE_IMAGE: dankempster/raspbian-jessie-ansible
+MOLECULE_IMAGE: dankempster/jenkins-raspbian-jessie-ansible

--- a/molecule/raspbian_stretch_env.yml
+++ b/molecule/raspbian_stretch_env.yml
@@ -1,3 +1,3 @@
 ---
 MOLECULE_DISTRO: rasp_stretch
-MOLECULE_IMAGE: dankempster/raspbian-stretch-ansible
+MOLECULE_IMAGE: dankempster/jenkins-raspbian-stretch-ansible

--- a/molecule/raspbian_stretch_env.yml
+++ b/molecule/raspbian_stretch_env.yml
@@ -1,3 +1,3 @@
 ---
 MOLECULE_DISTRO: rasp_stretch
-MOLECULE_IMAGE: dankempster/jenkins-raspbian-stretch-ansible
+MOLECULE_IMAGE: "dankempster/jenkins-raspbian-stretch-ansible:develop"

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -10,6 +10,7 @@
     state: present
   become: true
   when: not jenkins_farm_enabled
+    and jenkins_install_distro_packages | count > 0
 
 - name: Install pip packages
   pip:
@@ -17,6 +18,7 @@
     state: present
   become: true
   when: not jenkins_farm_enabled
+    and jenkins_install_pip_packages | count > 0
 
 #
 #
@@ -28,6 +30,7 @@
     state: present
   become: true
   when: jenkins_farm_enabled
+    and jenkins_install_distro_packages | count > 0
 
 - name: Install pip packages on all nodes
   pip:
@@ -35,3 +38,4 @@
     state: present
   become: true
   when: jenkins_farm_enabled
+    and jenkins_install_pip_packages | count > 0

--- a/tasks/install-plugins.yml
+++ b/tasks/install-plugins.yml
@@ -60,7 +60,8 @@
   become: true
 
 # ensure Jenkins is restarted if need be, by flushing the handlers
-- meta: flush_handlers
+- name: "Meta: Flush handlers"
+  meta: flush_handlers
 
 # wait for Jenkins to be available again
 - name: Wait for Jenkins to start up before proceeding.


### PR DESCRIPTION
Uses docker images with Jenkins built in to skip the Java/Jenkins install.

Seems this has reduced my test time by 10mins per distro.